### PR TITLE
Memory Allocation Context Stack

### DIFF
--- a/source/core/utilities/allocator.h
+++ b/source/core/utilities/allocator.h
@@ -38,10 +38,10 @@ typedef struct memory_allocator_context
 
 memory_allocator_context*   memory_pop_allocator();
 memory_allocator_context*   memory_get_current_allocator_context();
-void        memory_initialize_allocator_context();
-void        memory_push_allocator(memory_allocator_context *allocator);
-void*       memory_allocate(uint64_t size);
-void        memory_release(void *ptr);
+void                        memory_initialize_allocator_context();
+void                        memory_push_allocator(memory_allocator_context *allocator);
+void*                       memory_allocate(uint64_t size);
+void                        memory_release(void *ptr);
 
 #define memory_allocate_type(type) ((type*)memory_allocate(sizeof(type)))
 #define memory_allocate_array(type, size) ((type*)memory_allocate(sizeof(type)*size))

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -23,4 +23,9 @@ main(int argc, char ** argv)
     int runtime_code = environment_runtime();
     environment_shutdown(runtime_code);
 
+    // Before shutting down, we manually pop all the allocators off the stack
+    // so that they properly invoke any cleanup events before shutdown.
+    while (memory_get_current_allocator_context() != NULL)
+        memory_pop_allocator();
+
 }


### PR DESCRIPTION
Implemented a new allocation system meant to unify the front-end usage interface with multiple types of allocator types. The default allocator is the tracked malloc/free wrapper.

The system works by creating a stack, where the top-most stack is the allocator that gets used. Calls to `memory_allocate` and `memory_release` map to the top most allocator. When a different type of allocator is required, a call to `memory_push_allocator` can be used to place that new allocator at the top of the stack. All subsequent calls to `memory_allocate` and `memory_release` now point this allocator. Reverting back to the previous allocator requires a call to `memory_pop_allocator`. This functional also returns a pointer to the allocator that was just popped, in case the user wanted to use a previously pushed allocator and restore the popped allocator at a later time.

The main purpose of this system is to allow context-switching between the faster stack allocator, `memory_arena`, to a general purpose allocator such as `malloc` and `free`. The ultimate goal is to replace the C standard library's general memory allocator with a custom general allocator that fully integrates with same pool of memory that is gathered at the start of the application. This will prevent any memory allocation issues from arising that would prevent an otherwise functioning application from working due to a bad malloc.

